### PR TITLE
Made mixin less specific and added class to target body

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/components/health_check.scss
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/health_check.scss
@@ -1,16 +1,13 @@
 @mixin padBannerWith($size) {
-  p[role='banner'] {
-    padding-left: $size;
-    padding-right: $size;
-  }
+  padding-left: $size;
+  padding-right: $size;
 }
 
-.alertingHealthCheck {
+.alertingHealthCheck__body {
   @include padBannerWith(2 * $euiSize);
 }
 
-.alertingFlyoutHealthCheck {
+.alertingFlyoutHealthCheck__body {
   @include padBannerWith(2 * $euiSize);
-
   margin-top: $euiSize;
 }

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/health_check.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/health_check.tsx
@@ -82,24 +82,26 @@ const TlsAndEncryptionError = ({
       </h2>
     }
     body={
-      <p role="banner">
-        {i18n.translate('xpack.triggersActionsUI.components.healthCheck.tlsAndEncryptionError', {
-          defaultMessage:
-            'You must enable Transport Layer Security between Kibana and Elasticsearch and configure an encryption key in your kibana.yml file. ',
-        })}
-        <EuiLink
-          href={`${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/alerting-getting-started.html#alerting-setup-prerequisites`}
-          external
-          target="_blank"
-        >
-          {i18n.translate(
-            'xpack.triggersActionsUI.components.healthCheck.tlsAndEncryptionErrorAction',
-            {
-              defaultMessage: 'Learn how',
-            }
-          )}
-        </EuiLink>
-      </p>
+      <div className={`${className}__body`}>
+        <p role="banner">
+          {i18n.translate('xpack.triggersActionsUI.components.healthCheck.tlsAndEncryptionError', {
+            defaultMessage:
+              'You must enable Transport Layer Security between Kibana and Elasticsearch and configure an encryption key in your kibana.yml file. ',
+          })}
+          <EuiLink
+            href={`${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/alerting-getting-started.html#alerting-setup-prerequisites`}
+            external
+            target="_blank"
+          >
+            {i18n.translate(
+              'xpack.triggersActionsUI.components.healthCheck.tlsAndEncryptionErrorAction',
+              {
+                defaultMessage: 'Learn how',
+              }
+            )}
+          </EuiLink>
+        </p>
+      </div>
     }
   />
 );
@@ -122,24 +124,35 @@ const EncryptionError = ({
       </h2>
     }
     body={
-      <p role="banner">
-        {i18n.translate('xpack.triggersActionsUI.components.healthCheck.encryptionErrorBeforeKey', {
-          defaultMessage: 'To create an alert, set a value for ',
-        })}
-        <EuiCode>{'xpack.encrypted_saved_objects.encryptionKey'}</EuiCode>
-        {i18n.translate('xpack.triggersActionsUI.components.healthCheck.encryptionErrorAfterKey', {
-          defaultMessage: ' in your kibana.yml file. ',
-        })}
-        <EuiLink
-          href={`${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/alert-action-settings-kb.html#general-alert-action-settings`}
-          external
-          target="_blank"
-        >
-          {i18n.translate('xpack.triggersActionsUI.components.healthCheck.encryptionErrorAction', {
-            defaultMessage: 'Learn how.',
-          })}
-        </EuiLink>
-      </p>
+      <div className={`${className}__body`}>
+        <p role="banner">
+          {i18n.translate(
+            'xpack.triggersActionsUI.components.healthCheck.encryptionErrorBeforeKey',
+            {
+              defaultMessage: 'To create an alert, set a value for ',
+            }
+          )}
+          <EuiCode>{'xpack.encrypted_saved_objects.encryptionKey'}</EuiCode>
+          {i18n.translate(
+            'xpack.triggersActionsUI.components.healthCheck.encryptionErrorAfterKey',
+            {
+              defaultMessage: ' in your kibana.yml file. ',
+            }
+          )}
+          <EuiLink
+            href={`${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/alert-action-settings-kb.html#general-alert-action-settings`}
+            external
+            target="_blank"
+          >
+            {i18n.translate(
+              'xpack.triggersActionsUI.components.healthCheck.encryptionErrorAction',
+              {
+                defaultMessage: 'Learn how.',
+              }
+            )}
+          </EuiLink>
+        </p>
+      </div>
     }
   />
 );
@@ -162,21 +175,23 @@ const TlsError = ({
       </h2>
     }
     body={
-      <p role="banner">
-        {i18n.translate('xpack.triggersActionsUI.components.healthCheck.tlsError', {
-          defaultMessage:
-            'Alerting relies on API keys, which require TLS between Elasticsearch and Kibana. ',
-        })}
-        <EuiLink
-          href={`${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/configuring-tls.html`}
-          external
-          target="_blank"
-        >
-          {i18n.translate('xpack.triggersActionsUI.components.healthCheck.tlsErrorAction', {
-            defaultMessage: 'Learn how to enable TLS.',
+      <div className={`${className}__body`}>
+        <p role="banner">
+          {i18n.translate('xpack.triggersActionsUI.components.healthCheck.tlsError', {
+            defaultMessage:
+              'Alerting relies on API keys, which require TLS between Elasticsearch and Kibana. ',
           })}
-        </EuiLink>
-      </p>
+          <EuiLink
+            href={`${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/configuring-tls.html`}
+            external
+            target="_blank"
+          >
+            {i18n.translate('xpack.triggersActionsUI.components.healthCheck.tlsErrorAction', {
+              defaultMessage: 'Learn how to enable TLS.',
+            })}
+          </EuiLink>
+        </p>
+      </div>
     }
   />
 );


### PR DESCRIPTION
## Summary

@gmmorris Added a class so we can target the body of the `EmptyPrompt` and made the mixin less specific so that it's more flexible.
Also afaik we've been using the prefix `act` for Alerting classNames, we should try to be consistent with this.

I noticed there's a check to see if the `EmptyPrompt` is inside a flyout or not. However, I was getting the "inside flyout" className even though I wasn't seeing a flyout. See:

![image](https://user-images.githubusercontent.com/4016496/78808315-17c55200-797a-11ea-9dac-2f3691fdb6c2.png)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
